### PR TITLE
Add Windows start script

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,18 @@
+@echo off
+
+rem Build Docker images
+
+echo Building Docker images...
+docker-compose build
+
+rem Start containers
+
+echo Starting containers...
+docker-compose up -d
+
+rem Open default browser at the UI
+
+echo Launching browser...
+start "" http://localhost:8001
+
+


### PR DESCRIPTION
## Summary
- add a `start.bat` script

## Testing
- `make check` *(fails: Python 3.12 not supported)*
- `make test` *(fails: ModuleNotFoundError: No module named 'injector')*


------
https://chatgpt.com/codex/tasks/task_e_6870d66da59c8330ac6507a019a371e7