### PR TITLE
Improve startup robustness without Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,24 @@ Stay tuned to our [releases](https://github.com/zylon-ai/private-gpt/releases) t
 Full documentation on installation, dependencies, configuration, running the server, deployment options,
 ingesting local documents, API details and UI features can be found here: https://docs.privategpt.dev/
 
+## 🚀 Getting Started
+
+Run PrivateGPT either with Docker or directly using Poetry. When Docker is available you can simply execute
+
+```bash
+./start.sh
+```
+
+If Docker is not installed or cannot be started (e.g. in restricted environments), you can run everything
+locally using Poetry:
+
+```bash
+poetry install --extras "ui llms-llama-cpp embeddings-huggingface vector-stores-qdrant"
+PGPT_PROFILES=local make run
+```
+
+The UI will be available at <http://localhost:8001>.
+
 ## 🧩 Architecture
 Conceptually, PrivateGPT is an API that wraps a RAG pipeline and exposes its
 primitives.

--- a/start.sh
+++ b/start.sh
@@ -1,11 +1,23 @@
 #!/usr/bin/env bash
 set -e
 
-# Build Docker images
+if ! command -v docker >/dev/null 2>&1 || ! command -v docker-compose >/dev/null 2>&1; then
+    echo "Docker and docker-compose are required to run this script." >&2
+    echo "You can run PrivateGPT locally using Poetry instead:" >&2
+    echo "  PGPT_PROFILES=local make run" >&2
+    exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "Docker daemon is not running or not accessible." >&2
+    echo "Start Docker or run locally with:" >&2
+    echo "  PGPT_PROFILES=local make run" >&2
+    exit 1
+fi
+
 echo "Building Docker images..."
 docker-compose build
 
-# Start containers in the background
 echo "Starting containers..."
 docker-compose up -d
 


### PR DESCRIPTION
## Summary
- add instructions for running locally without Docker
- make `start.sh` fail fast if Docker is missing

## Testing
- `poetry install --with dev`
- `make test` *(fails: ImportError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6870db54b2388330b81ae87ecc980a3e